### PR TITLE
timeout, currentIndex -1, playlistchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,20 @@ player.playlist([{
 This functions allows you to either set or get the current item index.
 If called without arguments, it is a getter, with an argument, it is a setter.
 
+If the player is currently playing a non-playlist video, `currentItem` will return `-1`.
+
 ```js
 player.currentItem();
 // 0
 
 player.currentItem(2);
 // 2
+```
+
+```js
+player.playlist(samplePlaylist);
+player.src('http://example.com/video.mp4');
+player.playlist.currentItem(); // -1
 ```
 
 ### `player.playlist.next() -> Object`

--- a/README.md
+++ b/README.md
@@ -45,13 +45,17 @@ player.playlist.next();
 
 ## API
 
-* [`player.playlist([Array newPlaylist])`](#playerplaylistarray-newplaylist---array)
-* [`player.playlist.currentItem([Number newIndex])`](#playerplaylistcurrentitemnumber-newindex---number)
-* [`player.playlist.next()`](#playerplaylistnext---object)
-* [`player.playlist.previous()`](#playerplaylistprevious---object)
-* [`player.playlist.autoadvance()`](#playerplaylistautoadvancenumber-timeout---undefined)
+* [Methods](#methods)
+  * [`player.playlist([Array newPlaylist])`](#playerplaylistarray-newplaylist---array)
+  * [`player.playlist.currentItem([Number newIndex])`](#playerplaylistcurrentitemnumber-newindex---number)
+  * [`player.playlist.next()`](#playerplaylistnext---object)
+  * [`player.playlist.previous()`](#playerplaylistprevious---object)
+  * [`player.playlist.autoadvance()`](#playerplaylistautoadvancenumber-timeout---undefined)
+* [Events](#events)
+  * [`playlistchange`](#playlistchange)
 
-### `player.playlist([Array newPlaylist]) -> Array`
+### Methods
+#### `player.playlist([Array newPlaylist]) -> Array`
 This function allows you to either set or get the current playlist.
 If called without arguments, it is a getter, with an argument, it is a setter.
 
@@ -86,7 +90,7 @@ player.playlist([{
 // }]
 ```
 
-### `player.playlist.currentItem([Number newIndex]) -> Number`
+#### `player.playlist.currentItem([Number newIndex]) -> Number`
 This functions allows you to either set or get the current item index.
 If called without arguments, it is a getter, with an argument, it is a setter.
 
@@ -106,7 +110,7 @@ player.src('http://example.com/video.mp4');
 player.playlist.currentItem(); // -1
 ```
 
-### `player.playlist.next() -> Object`
+#### `player.playlist.next() -> Object`
 This functions allows you to advance to the next item in the playlist. You will receive the new playlist item back from this call. `player.playlist.currentItem` will be updated to return the new index.
 If you are at the end of the playlist, you will not be able to proceed past the end and instead will not receive anything back;
 
@@ -127,7 +131,7 @@ player.playlist.next();
 // undefined
 ```
 
-### `player.playlist.previous() -> Object`
+#### `player.playlist.previous() -> Object`
 This functions allows you to return to the previous item in the playlist. You will receive the new playlist item back from this call. `player.playlist.currentItem` will be updated to return the new index.
 If you are at the start of the playlist, you will not be able to proceed past the start and instead will not receive anything back;
 
@@ -150,7 +154,7 @@ player.playlist.previous();
 // undefined
 ```
 
-### `player.playlist.autoadvance([Number timeout]) -> undefined`
+#### `player.playlist.autoadvance([Number timeout]) -> undefined`
 This function allows you to set up playlist auto advancement. Once enabled it will wait a `timeout` amount of milliseconds at the end of a video before proceeding automatically to the next video.
 Any value which is not a positive, finite, integer, will be treated as a request to cancel and reset the auto advancing.
 If you change autoadvance during a timeout period, the auto advance will be canceled and it will not advance the next video but it will use the new timeout value for the following videos.
@@ -159,6 +163,24 @@ If you change autoadvance during a timeout period, the auto advance will be canc
 player.playlist.autoadvance(0); // will not wait before loading in the next item
 player.playlist.autoadvance(5); // will wait for 5 seconds before loading in the next item
 player.playlist.autoadvance(null); // reset and cancel the auto advance
+```
+
+### Events
+
+#### `playlistchange`
+This event is fired asynchronously whenever the playlist is changed.
+It is fired asynchronously to let the browser start loading the first video in the new playlist.
+
+```js
+player.on('playlistchange', function() {
+  console.log(player.playlist());
+});
+
+player.playlist([1,2,3]);
+// [1,2,3]
+
+player.playlist([4,5,6]);
+// [4,5,6]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you change autoadvance during a timeout period, the auto advance will be canc
 
 ```js
 player.playlist.autoadvance(0); // will not wait before loading in the next item
-player.playlist.autoadvance(5000); // will wait for 5 seconds before loading in the next item
+player.playlist.autoadvance(5); // will wait for 5 seconds before loading in the next item
 player.playlist.autoadvance(null); // reset and cancel the auto advance
 ```
 

--- a/src/autoadvance.js
+++ b/src/autoadvance.js
@@ -21,7 +21,7 @@ module.exports = function autoadvance(player, timeout) {
     player.playlist._timeoutId = window.setTimeout(function() {
       resetadvance();
       player.playlist.next();
-    }, timeout);
+    }, timeout * 1000);
   };
 
   // we called auto advance while an auto-advance was in progress

--- a/src/autoadvance.js
+++ b/src/autoadvance.js
@@ -1,32 +1,21 @@
+var resetadvance;
+
 module.exports = function autoadvance(player, timeout) {
-  var resetadvance = function resetadvance() {
-    if (player.playlist._timeoutId) {
-      window.clearTimeout(player.playlist._timeoutId);
-    }
-
-    if (player.playlist._ontimeout) {
-      player.off('ended', player.playlist._ontimeout);
-    }
-
-    player.playlist._timeoutId = null;
-    player.playlist._ontimeout = null;
-  };
-
   // we want to cancel the auto advance or auto advance was called with a bogus value
   if (typeof timeout !== 'number' || timeout !== timeout || timeout < 0 || timeout === Infinity) {
-    return resetadvance();
+    return resetadvance(player);
   }
 
   var ontimeout = function() {
     player.playlist._timeoutId = window.setTimeout(function() {
-      resetadvance();
+      resetadvance(player);
       player.playlist.next();
     }, timeout * 1000);
   };
 
   // we called auto advance while an auto-advance was in progress
   if (player.playlist._timeoutId) {
-    return resetadvance();
+    return resetadvance(player);
   }
 
   // we are starting a new video and don't have a timeout handler for it
@@ -36,7 +25,20 @@ module.exports = function autoadvance(player, timeout) {
   }
 
   // we want to reset the timeout for auto advance
-  resetadvance();
+  resetadvance(player);
   player.playlist._ontimeout = ontimeout;
   player.one('ended', ontimeout);
+};
+
+module.exports.resetadvance = resetadvance = function resetadvance(player) {
+  if (player.playlist._timeoutId) {
+    window.clearTimeout(player.playlist._timeoutId);
+  }
+
+  if (player.playlist._ontimeout) {
+    player.off('ended', player.playlist._ontimeout);
+  }
+
+  player.playlist._timeoutId = null;
+  player.playlist._ontimeout = null;
 };

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -5,9 +5,17 @@ var isArray = Array.isArray || function(array) {
 };
 var isInSources = function(arr, src) {
   var i = 0;
+  var j = 0;
+  var item;
+  var source;
+
   for (; i < arr.length; i++) {
-    if (arr[i] === src || arr.src === src) {
-      return true;
+    var item = arr[i];
+    for (; j < item.sources.length; j++) {
+      source = item.sources[j];
+      if (source && (source === src || source.src === src)) {
+        return true;
+      }
     }
   }
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -40,7 +40,10 @@ var playlistMaker = function(player, plist) {
   };
 
   playlist.currentItem = function item(index) {
-    if (typeof index === 'number' && index >= 0 && index < list.length) {
+    if (typeof index === 'number' &&
+        currentIndex !== index &&
+        index >= 0 &&
+        index < list.length) {
       currentIndex = index;
       playItem(player, autoadvanceTimeout, list[currentIndex]);
       return currentIndex;

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -3,6 +3,16 @@ var setupAutoadvance = require('./autoadvance.js');
 var isArray = Array.isArray || function(array) {
   return Object.prototype.toString.call(array) === '[object Array]';
 };
+var isInSources = function(arr, src) {
+  var i = 0;
+  for (; i < arr.length; i++) {
+    if (arr[i] === src || arr.src === src) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 // factory method to return a new playlist with the following API
 // playlist(["a", "b", "c"]) // setter, ["a", "b", "c"]
@@ -70,6 +80,14 @@ var playlistMaker = function(player, plist) {
   if (list.length) {
     playlist.currentItem(0);
   }
+
+  player.on('loadstart', function() {
+    var currentSrc = player.currentSrc();
+    if (!isInSources(list, currentSrc)) {
+      currentIndex = -1;
+      setupAutoadvance.resetadvance(player);
+    }
+  });
 
   return playlist;
 };

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -34,6 +34,10 @@ var playlistMaker = function(player, plist) {
     if (plist && isArray(plist)) {
       list = plist.slice();
       player.playlist.currentItem(0);
+
+      window.setTimeout(function() {
+        player.trigger('playlistchange');
+      }, 0);
     }
 
     return list.slice();

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -10,7 +10,7 @@ var isInSources = function(arr, src) {
   var source;
 
   for (; i < arr.length; i++) {
-    var item = arr[i];
+    item = arr[i];
     for (; j < item.sources.length; j++) {
       source = item.sources[j];
       if (source && (source === src || source.src === src)) {

--- a/test/autoadvance-test.js
+++ b/test/autoadvance-test.js
@@ -118,3 +118,20 @@ q.test('reset if we have already started advancing', function() {
 
   window.clearTimeout = oldClearTimeout;
 });
+
+q.test('timeout is given in seconds', function() {
+  var player = new videojs.EventEmitter(),
+      oldSetTimeout = window.setTimeout;
+
+  player.addEventListener = null;
+  player.playlist = {};
+
+  window.setTimeout = function(fn, timeout) {
+    q.equal(timeout, 10*1000, 'timeout was given in seconds');
+  };
+
+  autoadvance(player, 10);
+  player.trigger('ended');
+
+  window.setTimeout = oldSetTimeout;
+});

--- a/test/player-proxy.js
+++ b/test/player-proxy.js
@@ -7,6 +7,7 @@ module.exports = {
   addRemoteTextTrack: Function.prototype,
   removeRemoteTextTrack: Function.prototype,
   remoteTextTracks: Function.prototype,
+  on: Function.prototype,
   one: Function.prototype,
   off: Function.prototype,
   playlist: {

--- a/test/playlist-maker-test.js
+++ b/test/playlist-maker-test.js
@@ -152,5 +152,7 @@ q.test('loading a non-playlist video will cancel autoadvanec and set index of -1
 
   player.trigger('loadstart');
 
+  q.equal(playlist.currentItem(), -1, 'new currentItem is -1');
+
   autoadvance.resetadvance = oldReset;
 });

--- a/test/playlist-maker-test.js
+++ b/test/playlist-maker-test.js
@@ -65,6 +65,29 @@ q.test('playlist.currentItem() works as expected', function() {
   q.equal(playlist.currentItem(-Infinity), 2, 'cannot change to an invalid item');
 });
 
+q.test('playlist.currentItem() does not change items if same index is given', function() {
+  var player = extend(true, {}, playerProxy);
+  var sources = 0;
+  var playlist;
+
+  player.src = function() {
+    sources++;
+  };
+
+  playlist = playlistMaker(player, [{sources: 'sources'}, {sources: 'sources2'}]);
+
+  q.equal(playlist.currentItem(), 0, 'we start at index 0');
+
+  playlist.currentItem(0);
+  q.equal(sources, 0, 'we did not try to set sources');
+
+  playlist.currentItem(1);
+  q.equal(sources, 1, 'we did try to set sources');
+
+  playlist.currentItem(1);
+  q.equal(sources, 1, 'we did not try to set sources');
+});
+
 q.test('playlist.next() works as expected', function() {
   var playlist = playlistMaker(playerProxy, [1,2,3]);
 

--- a/test/playlist-maker-test.js
+++ b/test/playlist-maker-test.js
@@ -163,6 +163,16 @@ q.test('loading a non-playlist video will cancel autoadvanec and set index of -1
 
   q.equal(playlist.currentItem(), -1, 'new currentItem is -1');
 
+  player.currentSrc = function() {
+    return 'http://media.w3.org/2010/05/sintel/trailer.mp4';
+  };
+
+  autoadvance.resetadvance = function() {
+    q.ok(false, 'resetadvance should not be called');
+  };
+
+  player.trigger('loadstart');
+
   autoadvance.resetadvance = oldReset;
 });
 


### PR DESCRIPTION
This PR does several things:
* autoadvance timeout is now in seconds and not milliseconds
* `autoadvance` is reset whenever a non-playlist item is loaded
* `currentIndex` is set to -1 when a non-playlist item is loaded
* trigger `playlistchange` when the playlist is changed