### PR TITLE
indexOf fix

### DIFF
--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -110,7 +110,7 @@ var playlistMaker = function(player, plist) {
         source = sources[i];
         if (typeof source === 'string') {
           ret = indexInSources(list, source);
-        } else {
+        } else if (source.src) {
           ret = indexInSources(list, source.src);
         }
 

--- a/test/playlist-maker-test.js
+++ b/test/playlist-maker-test.js
@@ -229,6 +229,18 @@ q.test('playlist.contains() works as expected', function() {
 q.test('playlist.indexOf() works as expected', function() {
   var player = extend(true, {}, playerProxy);
   var playlist = playlistMaker(player, videoList);
+  var mixedSourcesPlaylist = playlistMaker(player, [{
+    sources: [{
+      src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+      type: 'video/mp4'
+    }, {
+      app_name: 'rtmp://example.com/sintel/trailer',
+      avg_bitrate: 4255000,
+      codec: 'H264',
+      container: 'MP4'
+    }],
+      poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+    }]);
   player.playlist = playlist;
 
   q.equal(playlist.indexOf('http://media.w3.org/2010/05/sintel/trailer.mp4'),
@@ -274,6 +286,32 @@ q.test('playlist.indexOf() works as expected', function() {
       type: 'video/mp4'
     }]
   }), -1, 'poster.png does not exist');
+
+  q.equal(mixedSourcesPlaylist.indexOf({
+    sources: [{
+      src: 'http://media.w3.org/2010/05/bunny/movie.mp4',
+      type: 'video/mp4'
+    }, {
+      app_name: 'rtmp://example.com/bunny/movie',
+      avg_bitrate: 4255000,
+      codec: 'H264',
+      container: 'MP4'
+    }],
+      poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+    }), -1, 'bunny movie does not exist');
+
+   q.equal(mixedSourcesPlaylist.indexOf({
+    sources: [{
+      src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+      type: 'video/mp4'
+    }, {
+      app_name: 'rtmp://example.com/sintel/trailer',
+      avg_bitrate: 4255000,
+      codec: 'H264',
+      container: 'MP4'
+    }],
+      poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+    }), 0, 'sinel trailer does exist');
 });
 
 q.test('playlist.next() works as expected', function() {


### PR DESCRIPTION
This fix is for situations where a catalog video contains a source object that does not contain a src property (some videos have a rtmp source). 

From
https://github.com/brightcove/videojs-playlist/blob/master/src/playlist-maker.js#L16
`source.src === src` evaluates to `undefined === undefined` and gives a false match.

I believe this issue is related to BC-35235