### PR TITLE
test for src undefined - fix for indexInSources()

### DIFF
--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -8,7 +8,12 @@ var indexInSources = function(arr, src) {
   var j = 0;
   var item;
   var source;
-
+  //If there is an rtmp source in the playlist, src comes out as undefined and indexOf incorrectly gives out the value as 0
+  //hence we make sure to hit the condition that if src is undefined just return -1 in the beginning itself
+  if (src === undefined) {
+    return -1;
+  }
+   
   for (; i < arr.length; i++) {
     item = arr[i];
     for (j = 0; j < item.sources.length; j++) {

--- a/test/playlist-maker-test.js
+++ b/test/playlist-maker-test.js
@@ -226,6 +226,16 @@ q.test('playlist.contains() works as expected', function() {
   }), 'we get false for a non-existent playlist item');
 });
 
+q.test('indexInSources is undefined',function(){
+  var player,playlist;
+  player = extend(true,{},playerProxy);
+  playlist = playlistMaker(player,videoList);
+  q.deepEqual(undefined,videoList[0].src,'videolist src 1 is undefined');
+  q.deepEqual(undefined,videoList[1].src,'videolist src 2 is undefined');
+  q.deepEqual(undefined,videoList[2].src,'videolist src 3 is undefined');
+  q.deepEqual(undefined,videoList[3].src,'videolist src 4 is undefined');
+});
+
 q.test('playlist.indexOf() works as expected', function() {
   var player = extend(true, {}, playerProxy);
   var playlist = playlistMaker(player, videoList);


### PR DESCRIPTION
Whenever src has rtmp sources within the function : `indexInSources = function(arr, src) {..} `the value comes out as undefined causing issues within indexOf() resulting in an incorrect value of 0 being given out instead of -1.