### PR TITLE
Bind `addRemoteTextTrack` to player instance

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -36,7 +36,7 @@ const playItem = (player, delay, item) => {
 
   clearTracks(player);
 
-  (item.textTracks || []).forEach(player.addRemoteTextTrack);
+  (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
 
   if (replay) {
     player.play();


### PR DESCRIPTION
Fixes #26 . Requires ES5 `Function.prototype.bind` or polyfill.