### PR TITLE
Add tracks after cue points

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -1,3 +1,4 @@
+import window from 'global/window';
 import {setup} from './auto-advance.js';
 
 /**
@@ -37,8 +38,6 @@ const playItem = (player, delay, item) => {
 
   clearTracks(player);
 
-  (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
-
   if (item.cuePoints && item.cuePoints.length) {
     let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
 
@@ -48,6 +47,8 @@ const playItem = (player, delay, item) => {
       trackEl.track.addCue(vttCue);
     });
   }
+
+  (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
 
   if (replay) {
     player.play();


### PR DESCRIPTION
This PR is to fix up some things from #24. Another BC plugin adds cue points then tracks to a player so this fix is to have consistent textTracks() ordering.