### PR TITLE
Adding in the small time value so that the IE does not throw syntax error on same start and end cue times

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -42,7 +42,7 @@ const playItem = (player, delay, item) => {
     let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
 
     item.cuePoints.forEach(cue => {
-      let vttCue = new Cue(cue.time, cue.time, cue.type);
+      let vttCue = new Cue(cue.time, cue.time + 1 / 60, cue.type);
 
       trackEl.track.addCue(vttCue);
     });


### PR DESCRIPTION
Adding in the small time change addition to the play-item.js file so that the IE does not throw syntax error when start and end cue times are same.