### PR TITLE
Fix for zero length cuepoints

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -42,7 +42,7 @@ const playItem = (player, delay, item) => {
     let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
 
     item.cuePoints.forEach(cue => {
-      let vttCue = new Cue(cue.time, cue.time, cue.type);
+      let vttCue = new Cue(cue.startTime, cue.endTime, cue.type);
 
       trackEl.track.addCue(vttCue);
     });

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -42,7 +42,8 @@ const playItem = (player, delay, item) => {
     let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
 
     item.cuePoints.forEach(cue => {
-      let vttCue = new Cue(cue.startTime, cue.endTime, cue.type);
+      let vttCue = new Cue(cue.time || cue.startTime || 0,
+        cue.time || cue.endTime || 0, cue.type);
 
       trackEl.track.addCue(vttCue);
     });

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -85,6 +85,68 @@ QUnit.test(
       {startTime: 1, endTime: 1.01667, type: 'bar' }],
       'cues are what we expected'
     );
+    window.VTTCue = oldVttCue;
+  }
+);
+
+QUnit.test(
+  'Backwards compatibility test to for setting sources, poster, tracks and cue points',
+  function(assert) {
+    let oldVttCue = window.VTTCue;
+    let player = playerProxyMaker();
+    let setSrc;
+    let setPoster;
+    let setTracks = [];
+    let cues = [];
+
+    window.VTTCue = (time, timeEnd, type) => ({time, type});
+
+    player.src = function(src) {
+      setSrc = src;
+    };
+
+    player.poster = function(poster) {
+      setPoster = poster;
+    };
+
+    player.addRemoteTextTrack = function(tt) {
+      setTracks.push(tt);
+      return {
+        track: {
+          addCue(cue) {
+            cues.push(cue);
+          }
+        }
+      };
+    };
+
+    playItem(player, null, {
+      sources: [1, 2, 3],
+      textTracks: [4, 5, 6],
+      poster: 'http://example.com/poster.png',
+      cuePoints: [{time: 0, type: 'foo' },
+      {time: 1, type: 'bar' }]
+    });
+
+    assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
+    assert.deepEqual(
+      setTracks.sort(),
+      [4, 5, 6, { kind: 'metadata' }].sort(),
+      'tracks are what we expected'
+    );
+
+    assert.equal(
+      setPoster,
+      'http://example.com/poster.png',
+      'poster is what we expected'
+    );
+
+    assert.deepEqual(
+      cues,
+      [{time: 0, type: 'foo' },
+      {time: 1, type: 'bar' }],
+      'cues are what we expected'
+    );
 
     window.VTTCue = oldVttCue;
   }

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -37,7 +37,7 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (time, timeEnd, type) => ({ startTime, endTime, type });
+    window.VTTCue = (startTime, endTime, type) => ({ startTime, endTime, type });
 
     player.src = function(src) {
       setSrc = src;
@@ -62,7 +62,7 @@ QUnit.test(
       sources: [1, 2, 3],
       textTracks: [4, 5, 6],
       poster: 'http://example.com/poster.png',
-      cuePoints: [{ startTime: 0, endTime: 0.166, type: 'foo' }, { startTime: 1, endTime: 1.166, type: 'bar' }]
+      cuePoints: [{ startTime:0, endTime:0.01667, type: 'foo' }, { startTime: 1, endTime: 1.01667, type: 'bar' }]
     });
 
     assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
@@ -80,7 +80,7 @@ QUnit.test(
 
     assert.deepEqual(
       cues,
-      [{ startTime: 0, endTime: 0.166, type: 'foo' }, { startTime: 1, endTime: 1.166 ,type: 'bar' }],
+      [{ startTime: 0, endTime: 0.01667, type: 'foo' }, { startTime: 1, endTime: 1.01667 ,type: 'bar' }],
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -37,7 +37,7 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (startTime, endTime, type) => ({ startTime, endTime, type });
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
 
     player.src = function(src) {
       setSrc = src;
@@ -62,7 +62,8 @@ QUnit.test(
       sources: [1, 2, 3],
       textTracks: [4, 5, 6],
       poster: 'http://example.com/poster.png',
-      cuePoints: [{ startTime:0, endTime:0.01667, type: 'foo' }, { startTime: 1, endTime: 1.01667, type: 'bar' }]
+      cuePoints: [{startTime: 0, endTime: 0.01667, type: 'foo' },
+      {startTime: 1, endTime: 1.01667, type: 'bar' }]
     });
 
     assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
@@ -80,7 +81,8 @@ QUnit.test(
 
     assert.deepEqual(
       cues,
-      [{ startTime: 0, endTime: 0.01667, type: 'foo' }, { startTime: 1, endTime: 1.01667 ,type: 'bar' }],
+      [{startTime: 0, endTime: 0.01667, type: 'foo' },
+      {startTime: 1, endTime: 1.01667, type: 'bar' }],
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -37,7 +37,7 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (time, timeEnd, type) => ({ time, type });
+    window.VTTCue = (time, timeEnd, type) => ({ startTime, endTime, type });
 
     player.src = function(src) {
       setSrc = src;
@@ -62,7 +62,7 @@ QUnit.test(
       sources: [1, 2, 3],
       textTracks: [4, 5, 6],
       poster: 'http://example.com/poster.png',
-      cuePoints: [{ time: 0, type: 'foo' }, { time: 1, type: 'bar' }]
+      cuePoints: [{ startTime: 0, endTime: 0.166, type: 'foo' }, { startTime: 1, endTime: 1.166, type: 'bar' }]
     });
 
     assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
@@ -80,7 +80,7 @@ QUnit.test(
 
     assert.deepEqual(
       cues,
-      [{ time: 0, type: 'foo' }, { time: 1, type: 'bar' }],
+      [{ startTime: 0, endTime: 0.166, type: 'foo' }, { startTime: 1, endTime: 1.166 ,type: 'bar' }],
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -90,24 +90,14 @@ QUnit.test(
 );
 
 QUnit.test(
-  'Backwards compatibility test for setting sources, poster, tracks and cue points',
+  'Backwards compatibility test for old cue points property using just time',
   function(assert) {
     let oldVttCue = window.VTTCue;
     let player = playerProxyMaker();
-    let setSrc;
-    let setPoster;
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type});
-
-    player.src = function(src) {
-      setSrc = src;
-    };
-
-    player.poster = function(poster) {
-      setPoster = poster;
-    };
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
 
     player.addRemoteTextTrack = function(tt) {
       setTracks.push(tt);
@@ -121,25 +111,9 @@ QUnit.test(
     };
 
     playItem(player, null, {
-      sources: [1, 2, 3],
-      textTracks: [4, 5, 6],
-      poster: 'http://example.com/poster.png',
       cuePoints: [{time: 0, type: 'foo' },
       {time: 1, type: 'bar' }]
     });
-
-    assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
-    assert.deepEqual(
-      setTracks.sort(),
-      [4, 5, 6, { kind: 'metadata' }].sort(),
-      'tracks are what we expected'
-    );
-
-    assert.equal(
-      setPoster,
-      'http://example.com/poster.png',
-      'poster is what we expected'
-    );
 
     assert.deepEqual(
       cues,

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -90,7 +90,7 @@ QUnit.test(
 );
 
 QUnit.test(
-  'Backwards compatibility test to for setting sources, poster, tracks and cue points',
+  'Backwards compatibility test for setting sources, poster, tracks and cue points',
   function(assert) {
     let oldVttCue = window.VTTCue;
     let player = playerProxyMaker();

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -99,7 +99,7 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (time, timeEnd, type) => ({time, type});
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type});
 
     player.src = function(src) {
       setSrc = src;
@@ -143,8 +143,8 @@ QUnit.test(
 
     assert.deepEqual(
       cues,
-      [{time: 0, type: 'foo' },
-      {time: 1, type: 'bar' }],
+      [{startTime: 0, endTime: 0, type: 'foo' },
+      {startTime: 1, endTime: 1, type: 'bar' }],
       'cues are what we expected'
     );
 


### PR DESCRIPTION
This PR is for avoiding zero length cuepoint errors.
We are adding a small time to the endTime of a cuepoint, so that zero length cues(same startTime and endTime cues) do not throw out errors. 