### PR TITLE
Load playlist with initial video at specified index or no starting video

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@
 
 - [Playlist Item Object](#playlist-item-object)
 - [Methods](#methods)
-  - [`player.playlist([Array newList]) -> Array`](#playerplaylistarray-newlist---array)
+  - [`player.playlist([Array newList], [Number newIndex]) -> Array`](#playerplaylistarray-newlist-number-newindex---array)
     - [`player.playlist.currentItem([Number index]) -> Number`](#playerplaylistcurrentitemnumber-index---number)
     - [`player.playlist.contains(String|Object|Array value) -> Boolean`](#playerplaylistcontainsstringobjectarray-value---boolean)
     - [`player.playlist.indexOf(String|Object|Array value) -> Number`](#playerplaylistindexofstringobjectarray-value---number)
@@ -31,7 +31,7 @@ Property   | Type   | Optional | Description
 
 ## Methods
 
-### `player.playlist([Array newList]) -> Array`
+### `player.playlist([Array newList], [Number newIndex]) -> Array`
 
 Get or set the current playlist for a player.
 
@@ -78,6 +78,26 @@ player.playlist([{
   }],
   poster: 'http://media.w3.org/2010/05/video/poster.png'
 }]);
+// [{ ... }]
+```
+
+If a setter, a second argument sets the video to be loaded. If omitted, the
+first video is loaded. If `-1`, no video is loaded.
+
+```js
+player.playlist([{
+  sources: [{
+    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    type: 'video/mp4'
+  }],
+  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+}, {
+  sources: [{
+    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    type: 'video/mp4'
+  }],
+  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+}], 1);
 // [{ ... }]
 ```
 
@@ -233,7 +253,7 @@ If you change auto-advance during a delay, the auto-advance will be canceled and
 player.playlist.autoadvance(0);
 
 // wait 5 seconds before loading in the next item
-player.playlist.autoadvance(5); 
+player.playlist.autoadvance(5);
 
 // reset and cancel the auto-advance
 player.playlist.autoadvance();

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -51,11 +51,15 @@ const indexInSources = (arr, src) => {
  * @param  {Array}  [initialList]
  *         If given, an initial list of sources with which to populate
  *         the playlist.
+ * @param  {Number}  [initialIndex]
+ *         If given, the index of the item in the list that should
+ *         be loaded first. If -1, no video is loaded. If omitted, The
+ *         the first video is loaded.
  *
  * @return {Function}
  *         Returns the playlist function specific to the given player.
  */
-const factory = (player, initialList) => {
+const factory = (player, initialList, initialIndex = 0) => {
   let list = Array.isArray(initialList) ? initialList.slice() : [];
 
   /**
@@ -67,13 +71,19 @@ const factory = (player, initialList) => {
    * @param  {Array} [newList]
    *         If given, a new list of sources with which to populate the
    *         playlist. Without this, the function acts as a getter.
+   * @param  {Number}  [newIndex]
+   *         If given, the index of the item in the list that should
+   *         be loaded first. If -1, no video is loaded. If omitted, The
+   *         the first video is loaded.
    *
    * @return {Array}
    */
-  const playlist = player.playlist = function(newList) {
+  const playlist = player.playlist = function(newList, newIndex = 0) {
     if (Array.isArray(newList)) {
       list = newList.slice();
-      playlist.first();
+      if (newIndex !== -1) {
+        playlist.currentItem(newIndex);
+      }
       playlist.changeTimeout_ = window.setTimeout(() => {
         player.trigger('playlistchange');
       }, 0);
@@ -235,7 +245,7 @@ const factory = (player, initialList) => {
     }
   });
 
-  playlist.first();
+  playlist.currentItem(initialIndex);
 
   return playlist;
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,8 +7,8 @@ import playlistMaker from './playlist-maker';
  *
  * @param {Array} list
  */
-const plugin = function(list) {
-  playlistMaker(this, list);
+const plugin = function(list, item) {
+  playlistMaker(this, list, item);
 };
 
 videojs.plugin('playlist', plugin);

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -73,7 +73,7 @@ QUnit.test(
   }
 );
 
-QUnit.test('playlistMaker can either take nothing or only an Array', function(assert) {
+QUnit.test('playlistMaker can either take nothing or an Array as its first argument', function(assert) {
   let playlist1 = playlistMaker(playerProxyMaker());
   let playlist2 = playlistMaker(playerProxyMaker(), 'foo');
   let playlist3 = playlistMaker(playerProxyMaker(), {foo: [1, 2, 3]});
@@ -226,6 +226,62 @@ QUnit.test(
     assert.equal(sources, 1, 'we did not try to set sources');
   }
 );
+
+QUnit.test('playlistMaker accepts a starting index', function(assert) {
+  let player = playerProxyMaker();
+  let src;
+
+  player.src = function(s) {
+    if (s) {
+      if (typeof s === 'string') {
+        src = s;
+      } else if (Array.isArray(s)) {
+        return player.src(s[0]);
+      } else {
+        return player.src(s.src);
+      }
+    }
+  };
+
+  player.currentSrc = function() {
+    return src;
+  };
+
+  let playlist = playlistMaker(player, videoList, 1);
+
+  assert.equal(
+    playlist.currentItem(), 1, 'if given an initial index, load that video'
+  );
+
+});
+
+QUnit.test('playlistMaker accepts a starting index', function(assert) {
+  let player = playerProxyMaker();
+  let src;
+
+  player.src = function(s) {
+    if (s) {
+      if (typeof s === 'string') {
+        src = s;
+      } else if (Array.isArray(s)) {
+        return player.src(s[0]);
+      } else {
+        return player.src(s.src);
+      }
+    }
+  };
+
+  player.currentSrc = function() {
+    return src;
+  };
+
+  let playlist = playlistMaker(player, videoList, -1);
+
+  assert.equal(
+    playlist.currentItem(), -1, 'if given -1 as initial index, load no video'
+  );
+
+});
 
 QUnit.test('playlist.contains() works as expected', function(assert) {
   let player = playerProxyMaker();


### PR DESCRIPTION
## Description
Allows the starting index of a playlist to be specified to load a video other than [0] into the player, or no video.
Use cases:
- Playlists that should start on a "featured" item which is not first in the list
- Facilitates direct linking
- Playlists that do not include the content currently playing, e.g. related videos
- Loaded new playlists without interrupting currently playback, e.g. a category tabs UI 

Example: http://jsbin.com/diyove/edit?html,output

## Specific Changes proposed
`playlist()` takes an additional Number argument for the starting index, defaulting to 0 if not specified. When the playlist is loaded `currentItem()` is used instead of `first()`. An index of `-1` results in playlist loaded but no video from the playlist loaded into the player. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [x] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors