### PR TITLE
Fix time property

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -42,8 +42,9 @@ const playItem = (player, delay, item) => {
     let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
 
     item.cuePoints.forEach(cue => {
+
       let vttCue = new Cue(cue.time || cue.startTime || 0,
-        cue.time || cue.endTime || 0, cue.type);
+        cue.endTime || cue.time || 0, cue.type);
 
       trackEl.track.addCue(vttCue);
     });

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -37,7 +37,11 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
+<<<<<<< HEAD
     window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
+=======
+    window.VTTCue = (startTime, endTime, type) => ({ startTime, endTime, type });
+>>>>>>> Tests Fixed
 
     player.src = function(src) {
       setSrc = src;
@@ -64,7 +68,6 @@ QUnit.test(
       poster: 'http://example.com/poster.png',
       cuePoints: [{startTime: 0, endTime: 0.01667, type: 'foo' },
       {startTime: 1, endTime: 1.01667, type: 'bar' }]
-
     });
 
     assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
@@ -120,7 +123,6 @@ QUnit.test(
       cues,
       [{startTime: 0, endTime: 0, type: 'foo' },
       {startTime: 1, endTime: 1, type: 'bar' }],
-
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -64,6 +64,7 @@ QUnit.test(
       poster: 'http://example.com/poster.png',
       cuePoints: [{startTime: 0, endTime: 0.01667, type: 'foo' },
       {startTime: 1, endTime: 1.01667, type: 'bar' }]
+
     });
 
     assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
@@ -119,6 +120,7 @@ QUnit.test(
       cues,
       [{startTime: 0, endTime: 0, type: 'foo' },
       {startTime: 1, endTime: 1, type: 'bar' }],
+
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -123,6 +123,68 @@ QUnit.test(
       {startTime: 1, endTime: 1, type: 'bar' }],
       'cues are what we expected'
     );
+    window.VTTCue = oldVttCue;
+  }
+);
+
+QUnit.test(
+  'Backwards compatibility test to for setting sources, poster, tracks and cue points',
+  function(assert) {
+    let oldVttCue = window.VTTCue;
+    let player = playerProxyMaker();
+    let setSrc;
+    let setPoster;
+    let setTracks = [];
+    let cues = [];
+
+    window.VTTCue = (time, timeEnd, type) => ({time, type});
+
+    player.src = function(src) {
+      setSrc = src;
+    };
+
+    player.poster = function(poster) {
+      setPoster = poster;
+    };
+
+    player.addRemoteTextTrack = function(tt) {
+      setTracks.push(tt);
+      return {
+        track: {
+          addCue(cue) {
+            cues.push(cue);
+          }
+        }
+      };
+    };
+
+    playItem(player, null, {
+      sources: [1, 2, 3],
+      textTracks: [4, 5, 6],
+      poster: 'http://example.com/poster.png',
+      cuePoints: [{time: 0, type: 'foo' },
+      {time: 1, type: 'bar' }]
+    });
+
+    assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
+    assert.deepEqual(
+      setTracks.sort(),
+      [4, 5, 6, { kind: 'metadata' }].sort(),
+      'tracks are what we expected'
+    );
+
+    assert.equal(
+      setPoster,
+      'http://example.com/poster.png',
+      'poster is what we expected'
+    );
+
+    assert.deepEqual(
+      cues,
+      [{time: 0, type: 'foo' },
+      {time: 1, type: 'bar' }],
+      'cues are what we expected'
+    );
 
     window.VTTCue = oldVttCue;
   }

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -128,7 +128,7 @@ QUnit.test(
 );
 
 QUnit.test(
-  'Backwards compatibility test to for setting sources, poster, tracks and cue points',
+  'Backwards compatibility test for setting sources, poster, tracks and cue points',
   function(assert) {
     let oldVttCue = window.VTTCue;
     let player = playerProxyMaker();

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -128,24 +128,14 @@ QUnit.test(
 );
 
 QUnit.test(
-  'Backwards compatibility test for setting sources, poster, tracks and cue points',
+  'Backwards compatibility test for old cue points property using just time',
   function(assert) {
     let oldVttCue = window.VTTCue;
     let player = playerProxyMaker();
-    let setSrc;
-    let setPoster;
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type});
-
-    player.src = function(src) {
-      setSrc = src;
-    };
-
-    player.poster = function(poster) {
-      setPoster = poster;
-    };
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
 
     player.addRemoteTextTrack = function(tt) {
       setTracks.push(tt);
@@ -159,25 +149,9 @@ QUnit.test(
     };
 
     playItem(player, null, {
-      sources: [1, 2, 3],
-      textTracks: [4, 5, 6],
-      poster: 'http://example.com/poster.png',
       cuePoints: [{time: 0, type: 'foo' },
       {time: 1, type: 'bar' }]
     });
-
-    assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
-    assert.deepEqual(
-      setTracks.sort(),
-      [4, 5, 6, { kind: 'metadata' }].sort(),
-      'tracks are what we expected'
-    );
-
-    assert.equal(
-      setPoster,
-      'http://example.com/poster.png',
-      'poster is what we expected'
-    );
 
     assert.deepEqual(
       cues,

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -137,7 +137,7 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-    window.VTTCue = (time, timeEnd, type) => ({time, type});
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type});
 
     player.src = function(src) {
       setSrc = src;
@@ -181,8 +181,8 @@ QUnit.test(
 
     assert.deepEqual(
       cues,
-      [{time: 0, type: 'foo' },
-      {time: 1, type: 'bar' }],
+      [{startTime: 0, endTime: 0, type: 'foo' },
+      {startTime: 1, endTime: 1, type: 'bar' }],
       'cues are what we expected'
     );
 

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -37,11 +37,8 @@ QUnit.test(
     let setTracks = [];
     let cues = [];
 
-<<<<<<< HEAD
+
     window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
-=======
-    window.VTTCue = (startTime, endTime, type) => ({ startTime, endTime, type });
->>>>>>> Tests Fixed
 
     player.src = function(src) {
       setSrc = src;
@@ -87,6 +84,7 @@ QUnit.test(
       cues,
       [{startTime: 0, endTime: 0.01667, type: 'foo' },
       {startTime: 1, endTime: 1.01667, type: 'bar' }],
+
       'cues are what we expected'
     );
     window.VTTCue = oldVttCue;


### PR DESCRIPTION
This PR is for fixing the correct truth value, when using the OR operator while adding time and endTime.
We should be using endTime always and then time if there is no endTime property provided.