### PR TITLE
Changing the sequence of properties on OR expression

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -43,7 +43,7 @@ const playItem = (player, delay, item) => {
 
     item.cuePoints.forEach(cue => {
       let vttCue = new Cue(cue.time || cue.startTime || 0,
-        cue.time || cue.endTime || 0, cue.type);
+        cue.endTime || cue.time || 0, cue.type);
 
       trackEl.track.addCue(vttCue);
     });

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -126,6 +126,43 @@ QUnit.test(
   }
 );
 
+QUnit.test(
+  'Check if we are choosing endTime rather than time if time property exists in parallel',
+  function(assert) {
+    let oldVttCue = window.VTTCue;
+    let player = playerProxyMaker();
+    let setTracks = [];
+    let cues = [];
+
+    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
+
+    player.addRemoteTextTrack = function(tt) {
+      setTracks.push(tt);
+      return {
+        track: {
+          addCue(cue) {
+            cues.push(cue);
+          }
+        }
+      };
+    };
+
+    playItem(player, null, {
+      cuePoints: [{time: 0, endTime: 0.0166, type: 'foo' },
+      {time: 1, endTime: 1.0166, type: 'bar' }]
+    });
+
+    assert.deepEqual(
+      cues,
+      [{endTime: 0.0166, startTime: 0, type: 'foo' },
+      {endTime: 1.0166, startTime: 1, type: 'bar' }],
+      'We are not choosing the property endTime correctly'
+    );
+
+    window.VTTCue = oldVttCue;
+  }
+);
+
 QUnit.test('will not try to play if paused', function(assert) {
   let player = playerProxyMaker();
   let tryPlay = false;


### PR DESCRIPTION
Changing the sequence of how we are adding in the endTime , because we always want to have endTime evaluated first even when we have the property time.