### PR TITLE
Remove Brightcove VideoCloud-specific Code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,9 @@
     - [`player.playlist.previous() -> Object`](#playerplaylistprevious---object)
     - [`player.playlist.autoadvance([Number delay]) -> undefined`](#playerplaylistautoadvancenumber-delay---undefined)
 - [Events](#events)
-    - [`playlistchange`](#playlistchange)
+  - [`playlistchange`](#playlistchange)
+  - [`beforeplaylistitem`](#beforeplaylistitem)
+  - [`playlistitem`](#playlistitem)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -241,7 +243,7 @@ player.playlist.autoadvance();
 
 ## Events
 
-#### `playlistchange`
+### `playlistchange`
 
 This event is fired asynchronously whenever the contents of the playlist are changed (i.e., when `player.playlist()` is called with an argument).
 
@@ -258,3 +260,11 @@ player.playlist([ ... ]);
 player.playlist([ ... ]);
 // [ ... ]
 ```
+
+### `beforeplaylistitem`
+
+This event is fired before switching to a new content source within a playlist (i.e., when any of `currentItem()`, `first()`, or `last()` is called, but before the player's state has been changed).
+
+### `playlistitem`
+
+This event is fired when switching to a new content source within a playlist (i.e., when any of `currentItem()`, `first()`, or `last()` is called; after the player's state has been changed, but before playback has been resumed).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "object.assign": "^4.0.3",
     "video.js": "^5.12.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "global": "^4.3.0",
     "object.assign": "^4.0.3",
-    "video.js": "^5.0.0"
+    "video.js": "^5.12.1"
   },
   "devDependencies": {
     "babel": "^5.8.0",

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -2,22 +2,6 @@ import window from 'global/window';
 import {setup} from './auto-advance.js';
 
 /**
- * Removes all remote text tracks from a player.
- *
- * @param  {Player} player
- */
-const clearTracks = (player) => {
-  let tracks = player.remoteTextTracks();
-  let i = tracks && tracks.length || 0;
-
-  // This uses a `while` loop rather than `forEach` because the
-  // `TextTrackList` object is a live DOM list (not an array).
-  while (i--) {
-    player.removeRemoteTextTrack(tracks[i]);
-  }
-};
-
-/**
  * Plays an item on a player's playlist.
  *
  * @param  {Player} player
@@ -30,29 +14,13 @@ const clearTracks = (player) => {
  * @return {Player}
  */
 const playItem = (player, delay, item) => {
-  let Cue = window.VTTCue || window.TextTrackCue;
+  player.trigger('beforeplaylistitem', item);
+
   let replay = !player.paused() || player.ended();
 
   player.poster(item.poster || '');
   player.src(item.sources);
-
-  clearTracks(player);
-
-  if (item.cuePoints && item.cuePoints.length) {
-    let trackEl = player.addRemoteTextTrack({ kind: 'metadata' });
-
-    item.cuePoints.forEach(cue => {
-      let vttCue = new Cue(
-        cue.startTime || cue.time || 0,
-        cue.endTime || cue.time || 0,
-        cue.type
-      );
-
-      trackEl.track.addCue(vttCue);
-    });
-  }
-
-  (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
+  player.trigger('playlistitem', item);
 
   if (replay) {
     player.play();
@@ -64,4 +32,3 @@ const playItem = (player, delay, item) => {
 };
 
 export default playItem;
-export {clearTracks};

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -1,4 +1,3 @@
-import window from 'global/window';
 import {setup} from './auto-advance.js';
 
 /**

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -1,6 +1,22 @@
 import window from 'global/window';
 import {setup} from './auto-advance.js';
 
+ /**
+  * Removes all remote text tracks from a player.
+  *
+  * @param  {Player} player
+  */
+ const clearTracks = (player) => {
+   const tracks = player.remoteTextTracks();
+   let i = tracks && tracks.length || 0;
+
+   // This uses a `while` loop rather than `forEach` because the
+   // `TextTrackList` object is a live DOM list (not an array).
+   while (i--) {
+     player.removeRemoteTextTrack(tracks[i]);
+   }
+ };
+
 /**
  * Plays an item on a player's playlist.
  *
@@ -14,12 +30,13 @@ import {setup} from './auto-advance.js';
  * @return {Player}
  */
 const playItem = (player, delay, item) => {
+  const replay = !player.paused() || player.ended();
+
   player.trigger('beforeplaylistitem', item);
-
-  let replay = !player.paused() || player.ended();
-
   player.poster(item.poster || '');
   player.src(item.sources);
+  clearTracks(player);
+  (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
   player.trigger('playlistitem', item);
 
   if (replay) {
@@ -32,3 +49,4 @@ const playItem = (player, delay, item) => {
 };
 
 export default playItem;
+export {clearTracks};

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -1,21 +1,21 @@
 import window from 'global/window';
 import {setup} from './auto-advance.js';
 
- /**
-  * Removes all remote text tracks from a player.
-  *
-  * @param  {Player} player
-  */
- const clearTracks = (player) => {
-   const tracks = player.remoteTextTracks();
-   let i = tracks && tracks.length || 0;
+/**
+ * Removes all remote text tracks from a player.
+ *
+ * @param  {Player} player
+ */
+const clearTracks = (player) => {
+  const tracks = player.remoteTextTracks();
+  let i = tracks && tracks.length || 0;
 
-   // This uses a `while` loop rather than `forEach` because the
-   // `TextTrackList` object is a live DOM list (not an array).
-   while (i--) {
-     player.removeRemoteTextTrack(tracks[i]);
-   }
- };
+  // This uses a `while` loop rather than `forEach` because the
+  // `TextTrackList` object is a live DOM list (not an array).
+  while (i--) {
+    player.removeRemoteTextTrack(tracks[i]);
+  }
+};
 
 /**
  * Plays an item on a player's playlist.

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -131,7 +131,6 @@ const factory = (player, initialList) => {
 
   player.on('dispose', () => {
     window.clearTimeout(playlist.changeTimeout_);
-    playlist.changeTimeout_ = null;
   });
 
   assign(playlist, {

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -1,5 +1,4 @@
 import window from 'global/window';
-import videojs from 'video.js';
 import playItem from './play-item';
 import * as autoadvance from './auto-advance';
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -1,7 +1,16 @@
 import window from 'global/window';
-import assign from 'object.assign';
+import videojs from 'video.js';
 import playItem from './play-item';
 import * as autoadvance from './auto-advance';
+
+// Lightweight Object.assign alternative.
+const assign = (target, source) => {
+  for (let key in source) {
+    if (source.hasOwnProperty(key)) {
+      target[key] = source[key];
+    }
+  }
+};
 
 /**
  * Given two sources, check to see whether the two sources are equal.
@@ -122,6 +131,7 @@ const factory = (player, initialList) => {
 
   player.on('dispose', () => {
     window.clearTimeout(playlist.changeTimeout_);
+    playlist.changeTimeout_ = null;
   });
 
   assign(playlist, {

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -1,171 +1,9 @@
 import QUnit from 'qunit';
+import sinon from 'sinon';
 import playItem from '../src/play-item';
-import {clearTracks} from '../src/play-item';
 import playerProxyMaker from './player-proxy-maker';
 
 QUnit.module('play-item');
-
-QUnit.test('clearTracks will try and remove all tracks', function(assert) {
-  let player = playerProxyMaker();
-  let remoteTracks = [1, 2, 3];
-  let removedTracks = [];
-
-  player.remoteTextTracks = function() {
-    return remoteTracks;
-  };
-
-  player.removeRemoteTextTrack = function(tt) {
-    removedTracks.push(tt);
-  };
-
-  clearTracks(player);
-
-  assert.deepEqual(
-    removedTracks.sort(),
-    remoteTracks.sort(),
-    'the removed tracks are equivalent to our remote tracks'
-  );
-});
-
-QUnit.test(
-  'playItem() works as expected for setting sources, poster, tracks and cue points',
-  function(assert) {
-    let oldVttCue = window.VTTCue;
-    let player = playerProxyMaker();
-    let setSrc;
-    let setPoster;
-    let setTracks = [];
-    let cues = [];
-
-    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
-
-    player.src = function(src) {
-      setSrc = src;
-    };
-
-    player.poster = function(poster) {
-      setPoster = poster;
-    };
-
-    player.addRemoteTextTrack = function(tt) {
-      setTracks.push(tt);
-      return {
-        track: {
-          addCue(cue) {
-            cues.push(cue);
-          }
-        }
-      };
-    };
-
-    playItem(player, null, {
-      sources: [1, 2, 3],
-      textTracks: [4, 5, 6],
-      poster: 'http://example.com/poster.png',
-      cuePoints: [{startTime: 0, endTime: 0.01667, type: 'foo' },
-      {startTime: 1, endTime: 1.01667, type: 'bar' }]
-    });
-
-    assert.deepEqual(setSrc, [1, 2, 3], 'sources are what we expected');
-    assert.deepEqual(
-      setTracks.sort(),
-      [4, 5, 6, { kind: 'metadata' }].sort(),
-      'tracks are what we expected'
-    );
-
-    assert.equal(
-      setPoster,
-      'http://example.com/poster.png',
-      'poster is what we expected'
-    );
-
-    assert.deepEqual(
-      cues,
-      [{startTime: 0, endTime: 0.01667, type: 'foo' },
-      {startTime: 1, endTime: 1.01667, type: 'bar' }],
-      'cues are what we expected'
-    );
-    window.VTTCue = oldVttCue;
-  }
-);
-
-QUnit.test(
-  'Backwards compatibility test for old cue points property using just time',
-  function(assert) {
-    let oldVttCue = window.VTTCue;
-    let player = playerProxyMaker();
-    let setTracks = [];
-    let cues = [];
-
-    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type });
-
-    player.addRemoteTextTrack = function(tt) {
-      setTracks.push(tt);
-      return {
-        track: {
-          addCue(cue) {
-            cues.push(cue);
-          }
-        }
-      };
-    };
-
-    playItem(player, null, {
-      cuePoints: [{time: 0, type: 'foo' },
-      {time: 1, type: 'bar' }]
-    });
-
-    assert.deepEqual(
-      cues,
-      [{startTime: 0, endTime: 0, type: 'foo' },
-      {startTime: 1, endTime: 1, type: 'bar' }],
-      'cues are what we expected'
-    );
-
-    window.VTTCue = oldVttCue;
-  }
-);
-
-QUnit.test(
-  'ensure we are using startTime/endTime rather than time if possible',
-  function(assert) {
-    let oldVttCue = window.VTTCue;
-    let player = playerProxyMaker();
-    let setTracks = [];
-    let cues = [];
-
-    window.VTTCue = (startTime, endTime, type) => ({startTime, endTime, type});
-
-    player.addRemoteTextTrack = function(tt) {
-      setTracks.push(tt);
-      return {
-        track: {
-          addCue(cue) {
-            cues.push(cue);
-          }
-        }
-      };
-    };
-
-    playItem(player, null, {
-      cuePoints: [
-        {time: 0, endTime: 0.0166, startTime: 0.0111, type: 'foo' },
-        {time: 1, endTime: 1.0166, startTime: 1.0111, type: 'bar' }
-      ]
-    });
-
-    assert.deepEqual(
-      cues,
-      [
-        {endTime: 0.0166, startTime: 0.0111, type: 'foo' },
-        {endTime: 1.0166, startTime: 1.0111, type: 'bar' }
-      ],
-      'We are not choosing the property endTime correctly'
-    );
-
-    window.VTTCue = oldVttCue;
-  }
-);
 
 QUnit.test('will not try to play if paused', function(assert) {
   let player = playerProxyMaker();
@@ -181,7 +19,6 @@ QUnit.test('will not try to play if paused', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
-    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
@@ -202,7 +39,6 @@ QUnit.test('will try to play if not paused', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
-    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
@@ -227,7 +63,6 @@ QUnit.test('will not try to play if paused and not ended', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
-    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
@@ -252,9 +87,25 @@ QUnit.test('will try to play if paused and ended', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
-    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
   assert.ok(tryPlay, 'we replayed on not-paused');
+});
+
+QUnit.test('fires "beforeplaylistitem" and "playlistitem"', function(assert) {
+  const player = playerProxyMaker();
+  const beforeSpy = sinon.spy();
+  const spy = sinon.spy();
+
+  player.on('beforeplaylistitem', beforeSpy);
+  player.on('playlistitem', spy);
+
+  playItem(player, null, {
+    sources: [1, 2, 3],
+    poster: 'http://example.com/poster.png'
+  });
+
+  assert.strictEqual(beforeSpy.callCount, 1);
+  assert.strictEqual(spy.callCount, 1);
 });

--- a/test/play-item.test.js
+++ b/test/play-item.test.js
@@ -1,9 +1,32 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import playItem from '../src/play-item';
+import {clearTracks} from '../src/play-item';
 import playerProxyMaker from './player-proxy-maker';
 
 QUnit.module('play-item');
+
+QUnit.test('clearTracks will try and remove all tracks', function(assert) {
+  let player = playerProxyMaker();
+  let remoteTracks = [1, 2, 3];
+  let removedTracks = [];
+
+  player.remoteTextTracks = function() {
+    return remoteTracks;
+  };
+
+  player.removeRemoteTextTrack = function(tt) {
+    removedTracks.push(tt);
+  };
+
+  clearTracks(player);
+
+  assert.deepEqual(
+    removedTracks.sort(),
+    remoteTracks.sort(),
+    'the removed tracks are equivalent to our remote tracks'
+  );
+});
 
 QUnit.test('will not try to play if paused', function(assert) {
   let player = playerProxyMaker();
@@ -19,6 +42,7 @@ QUnit.test('will not try to play if paused', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
+    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
@@ -39,6 +63,7 @@ QUnit.test('will try to play if not paused', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
+    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 
@@ -63,6 +88,7 @@ QUnit.test('will not try to play if paused and not ended', function(assert) {
 
   playItem(player, null, {
     sources: [1, 2, 3],
+    textTracks: [4, 5, 6],
     poster: 'http://example.com/poster.png'
   });
 

--- a/test/player-proxy-maker.js
+++ b/test/player-proxy-maker.js
@@ -8,9 +8,6 @@ const proxy = (props) => {
     ended: Function.prototype,
     poster: Function.prototype,
     src: Function.prototype,
-    addRemoteTextTrack: Function.prototype,
-    removeRemoteTextTrack: Function.prototype,
-    remoteTextTracks: Function.prototype,
     currentSrc: Function.prototype,
     playlist: {
       autoadvance_: {},

--- a/test/player-proxy-maker.js
+++ b/test/player-proxy-maker.js
@@ -9,6 +9,9 @@ const proxy = (props) => {
     poster: Function.prototype,
     src: Function.prototype,
     currentSrc: Function.prototype,
+    addRemoteTextTrack: Function.prototype,
+    removeRemoteTextTrack: Function.prototype,
+    remoteTextTracks: Function.prototype,
     playlist: {
       autoadvance_: {},
       currentIndex_: -1,

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -576,19 +576,21 @@ QUnit.test(
   }
 );
 
-QUnit.test('when loading a new playlist, trigger "playlistchange" on the player', function(assert) {
-  const spy = sinon.spy();
-  const player = playerProxyMaker();
+QUnit.test(
+  'when loading a new playlist, trigger "playlistchange" on the player',
+  function(assert) {
+    const spy = sinon.spy();
+    const player = playerProxyMaker();
 
-  player.on('playlistchange', spy);
-  const playlist = playlistMaker(player, [1, 2, 3]);
+    player.on('playlistchange', spy);
+    const playlist = playlistMaker(player, [1, 2, 3]);
 
-  playlist([4, 5, 6]);
-  this.clock.tick(1);
+    playlist([4, 5, 6]);
+    this.clock.tick(1);
 
-  assert.strictEqual(spy.callCount, 1);
-  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
-});
+    assert.strictEqual(spy.callCount, 1);
+    assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+  });
 
 QUnit.test('clearTimeout on dispose', function(assert) {
   const player = playerProxyMaker();
@@ -596,6 +598,7 @@ QUnit.test('clearTimeout on dispose', function(assert) {
 
   playlist([1, 2, 3]);
   const clearSpy = sinon.spy(window, 'clearTimeout');
+
   player.trigger('dispose');
 
   assert.strictEqual(clearSpy.callCount, 1);

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -1,5 +1,6 @@
 import window from 'global/window';
 import QUnit from 'qunit';
+import sinon from 'sinon';
 import playlistMaker from '../src/playlist-maker';
 import * as autoadvance from '../src/auto-advance';
 import playerProxyMaker from './player-proxy-maker';
@@ -39,12 +40,11 @@ const videoList = [{
 QUnit.module('playlist', {
 
   beforeEach() {
-    this.oldTimeout = window.setTimeout;
-    window.setTimeout = Function.prototype;
+    this.clock = sinon.useFakeTimers();
   },
 
   afterEach() {
-    window.setTimeout = this.oldTimeout;
+    this.clock.restore();
   }
 });
 
@@ -576,47 +576,28 @@ QUnit.test(
   }
 );
 
-QUnit.test(
-  'when loading a new playlist, trigger "playlistchange" on the player',
-  function(assert) {
-    let oldTimeout = window.setTimeout;
-    let player = playerProxyMaker();
-    let playlist;
+QUnit.test('when loading a new playlist, trigger "playlistchange" on the player', function(assert) {
+  const spy = sinon.spy();
+  const player = playerProxyMaker();
 
-    window.setTimeout = function(fn, timeout) {
-      fn();
-    };
+  player.on('playlistchange', spy);
+  const playlist = playlistMaker(player, [1, 2, 3]);
 
-    player.trigger = function(type) {
-      assert.equal(type, 'playlistchange', 'trigger playlistchange on playlistchange');
-    };
+  playlist([4, 5, 6]);
+  this.clock.tick(1);
 
-    playlist = playlistMaker(player, [1, 2, 3]);
-
-    playlist([4, 5, 6]);
-
-    window.setTimeout = oldTimeout;
-  }
-);
+  assert.strictEqual(spy.callCount, 1);
+  assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
+});
 
 QUnit.test('clearTimeout on dispose', function(assert) {
-  let oldTimeout = window.setTimeout;
-  let oldClear = window.clearTimeout;
-  let timeout = 1;
-  let player = playerProxyMaker();
-  let playlist = playlistMaker(player, [1, 2, 3]);
-
-  window.setTimeout = function() {
-    return timeout;
-  };
-
-  window.clearTimeout = function(to) {
-    assert.equal(to, timeout, 'we cleared the timeout');
-  };
+  const player = playerProxyMaker();
+  const playlist = playlistMaker(player, [1, 2, 3]);
 
   playlist([1, 2, 3]);
+  const clearSpy = sinon.spy(window, 'clearTimeout');
   player.trigger('dispose');
 
-  window.setTimeout = oldTimeout;
-  window.clearTimeout = oldClear;
+  assert.strictEqual(clearSpy.callCount, 1);
+  clearSpy.restore();
 });


### PR DESCRIPTION
Even though this was an undocumented "feature" of this plugin, we should consider this a major-level change because it _is_ backward-incompatible.

Also, this adds two new events: `"beforeplaylistitem"` and `"playlistitem"`. Our internal code can hook into these to do the work that was previously done here.