### PR TITLE
Fix currentSrc not updating when loading playlist

### DIFF
--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -159,7 +159,8 @@ const factory = (player, initialList, initialIndex = 0) => {
     currentItem(index) {
       if (
         typeof index === 'number' &&
-        playlist.currentIndex_ !== index &&
+        (playlist.currentIndex_ !== index ||
+        playlist.indexOf(playlist.player_.currentSrc() || '') !== playlist.currentIndex_) &&
         index >= 0 &&
         index < list.length
       ) {

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -283,6 +283,46 @@ QUnit.test('playlistMaker accepts a starting index', function(assert) {
 
 });
 
+QUnit.test('playlistMaker updates the current source after using the same index', function(assert) {
+  let player = playerProxyMaker();
+  let src;
+
+  player.src = function(s) {
+    if (s) {
+      if (typeof s === 'string') {
+        src = s;
+      } else if (Array.isArray(s)) {
+        return player.src(s[0]);
+      } else {
+        return player.src(s.src);
+      }
+    }
+  };
+
+  player.currentSrc = function() {
+    return src;
+  };
+
+  let playlist = playlistMaker(player, videoList, 1);
+
+  assert.equal(
+      playlist.currentItem(), 1, 'if given an initial index, load that video'
+  );
+
+  playlist(videoList.slice(-2), 1);
+
+  assert.equal(
+      playlist.currentItem(), 1, 'if given the same initial index, load that video'
+  );
+
+  assert.equal(
+      player.currentSrc(),
+      'http://media.w3.org/2010/05/video/movie_300.mp4',
+      'if given the same initial index, currentSrc is updated with the new playlist item'
+  );
+
+});
+
 QUnit.test('playlist.contains() works as expected', function(assert) {
   let player = playerProxyMaker();
   let playlist = playlistMaker(player, videoList);


### PR DESCRIPTION
### Expectation
When loading a new playlist the given index should be loaded in the player.

### Actual
When the index does not change it will prevent loading the updated playlist item in the player.

### Reproduce

1. Load a playlist by calling

```
player.playlist([{
  src: 'http://streaming.server/video1.mp4'
}, {
  src: 'http://streaming.server/video2.mp4'
}]);
```

2. Load a new playlist and use the same index as the current index

```
player.playlist([{
  src: 'http://streaming.server/video3.mp4'
}, {
  src: 'http://streaming.server/video4.mp4'
}], player.playlist.currentItem());
```

3. The source is not updated until changing currentItem using; `currentItem(1)`, `previous()` or `next()`.