### PR TITLE
ignore: Tweak and clarify the firing of 'duringplaylistchange' and 'playlistchange' events.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -433,6 +433,8 @@ This event is fired _after_ the contents of the playlist are changed when callin
 - `previousIndex`: The index from the previous playlist (will always match the current index when this event triggers, but is provided for completeness).
 - `previousPlaylist`: A shallow clone of the previous playlist.
 
+**NOTE**: This event fires every time `player.playlist()` is called - including the first time.
+
 #### Caveats
 
 During the firing of this event, the playlist is considered to be in a **changing state**, which has the following effects:
@@ -462,7 +464,7 @@ player.on('playlistchange', function() {
 
 ### `playlistchange`
 
-This event is fired asynchronously whenever the contents of the playlist are changed (i.e., when `player.playlist()` is called with an argument).
+This event is fired _asynchronously_ whenever the contents of the playlist are changed (i.e., when `player.playlist()` is called with an argument) - except the first time.
 
 It is fired asynchronously to let the browser start loading the first video in the new playlist.
 
@@ -477,6 +479,20 @@ player.playlist([]);
 player.playlist([]);
 // [ ... ]
 ```
+
+#### Backward Compatibility
+
+This event _does not fire_ the first time `player.playlist()` is called. If you want it to fire on the first call to `player.playlist()`, you can call it without an argument before calling it with one:
+
+```js
+// This will fire no events.
+player.playlist();
+
+// This will fire both "duringplaylistchange" and "playlistchange"
+player.playlist([...]);
+```
+
+This behavior will be removed in v5.0.0 and the event will fire in all cases.
 
 ### `beforeplaylistitem`
 

--- a/index.html
+++ b/index.html
@@ -73,6 +73,16 @@
       player.volume(0);
     } catch (e) {}
 
+    player.on([
+      'duringplaylistchange',
+      'playlistchange',
+      'beforeplaylistitem',
+      'playlistitem',
+      'playlistsorted'
+    ], function(e) {
+      videojs.log('player saw "' + e.type + '"');
+    });
+
     player.playlist(videoList);
 
     document.querySelector('.previous').addEventListener('click', function() {
@@ -86,15 +96,18 @@
     Array.prototype.forEach.call(document.querySelectorAll('[name=autoadvance]'), function(el) {
       el.addEventListener('click', function() {
         var value = document.querySelector('[name=autoadvance]:checked').value;
-        player.playlist.autoadvance(JSON.parse(value));
+        player.playlist.autoadvance(Number(value));
       });
     });
+
     document.querySelector('[name="autoadvance"][value="null"]').click();
 
     var repeatCheckbox = document.querySelector('.repeat');
+
     repeatCheckbox.addEventListener('click', function() {
       player.playlist.repeat(this.checked);
     });
+
     repeatCheckbox.checked = false;
   </script>
 </body>

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -724,6 +724,62 @@ QUnit.test('when loading a new playlist, trigger "playlistchange" on the player'
   assert.strictEqual(spy.firstCall.args[0].type, 'playlistchange');
 });
 
+QUnit.test('"duringplaylistchange" and "playlistchange" on first call without an initial list', function(assert) {
+  const changeSpy = sinon.spy();
+  const duringSpy = sinon.spy();
+  const player = playerProxyMaker();
+
+  player.on('playlistchange', changeSpy);
+  player.on('duringplaylistchange', duringSpy);
+
+  const playlist = playlistMaker(player);
+
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 0, 'on initial call, the "playlistchange" event did not fire');
+  assert.strictEqual(duringSpy.callCount, 0, 'on initial call, the "duringplaylistchange" event did not fire');
+
+  playlist([1]);
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 1, 'on second call, the "playlistchange" event did fire');
+  assert.strictEqual(duringSpy.callCount, 1, 'on second call, the "duringplaylistchange" event did fire');
+
+  playlist([2]);
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 2, 'on third call, the "playlistchange" event did fire');
+  assert.strictEqual(duringSpy.callCount, 2, 'on third call, the "duringplaylistchange" event did fire');
+});
+
+QUnit.test('"duringplaylistchange" and "playlistchange" on first call with an initial list', function(assert) {
+  const changeSpy = sinon.spy();
+  const duringSpy = sinon.spy();
+  const player = playerProxyMaker();
+
+  player.on('playlistchange', changeSpy);
+  player.on('duringplaylistchange', duringSpy);
+
+  const playlist = playlistMaker(player, [1]);
+
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 0, 'on initial call, the "playlistchange" event did not fire');
+  assert.strictEqual(duringSpy.callCount, 1, 'on initial call, the "duringplaylistchange" event did fire');
+
+  playlist([2]);
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 1, 'on second call, the "playlistchange" event did fire');
+  assert.strictEqual(duringSpy.callCount, 2, 'on second call, the "duringplaylistchange" event did fire');
+
+  playlist([3]);
+  this.clock.tick(1);
+
+  assert.strictEqual(changeSpy.callCount, 2, 'on third call, the "playlistchange" event did fire');
+  assert.strictEqual(duringSpy.callCount, 3, 'on third call, the "duringplaylistchange" event did fire');
+});
+
 QUnit.test('playlist.sort() works as expected', function(assert) {
   const player = playerProxyMaker();
   const spy = sinon.spy();


### PR DESCRIPTION
I realized after merging #92 that the event did not fire on the initial call to `playlist()`. Now, it will fire on the initial call, but `playlistchange` will _not_ fire for backward compatibility.

- `duringplaylistchange` will always fire.
- `playlistchange` will not fire the first time `playlist()` is call (backward compatibility).
- In v5.0.0, `playlistchange` will always fire.