### PR TITLE
fix: Fix regression(s) introduced by changes to the currentItem function in 4.3.0

### DIFF
--- a/src/play-item.js
+++ b/src/play-item.js
@@ -31,16 +31,24 @@ const clearTracks = (player) => {
  */
 const playItem = (player, item) => {
   const replay = !player.paused() || player.ended();
+  const playlist = player.playlist();
 
   player.trigger('beforeplaylistitem', item.originalValue || item);
   player.poster(item.poster || '');
   player.src(item.sources);
   clearTracks(player);
 
+  // Flag this source as having been set by the playlist plugin. Also set the
+  // flag when the next loadstart happens
+  playlist.currentSourceSetByPlaylist_ = true;
+  player.one('loadstart', () => {
+    playlist.currentSourceSetByPlaylist_ = true;
+  });
+
   player.ready(() => {
 
     if (item.playlistItemId_) {
-      player.playlist().currentPlaylistItemId_ = item.playlistItemId_;
+      playlist.currentPlaylistItemId_ = item.playlistItemId_;
     }
 
     (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -32,14 +32,19 @@ const clearTracks = (player) => {
 const playItem = (player, item) => {
   const replay = !player.paused() || player.ended();
 
-  player.trigger('beforeplaylistitem', item);
+  player.trigger('beforeplaylistitem', item.originalValue || item);
   player.poster(item.poster || '');
   player.src(item.sources);
   clearTracks(player);
 
   player.ready(() => {
+
+    if (item.playlistItemId_) {
+      player.playlist().currentPlaylistItemId_ = item.playlistItemId_;
+    }
+
     (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
-    player.trigger('playlistitem', item);
+    player.trigger('playlistitem', item.originalValue || item);
 
     if (replay) {
       const playPromise = player.play();

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -31,25 +31,18 @@ const clearTracks = (player) => {
  */
 const playItem = (player, item) => {
   const replay = !player.paused() || player.ended();
-  const playlist = player.playlist();
 
   player.trigger('beforeplaylistitem', item.originalValue || item);
+
+  if (item.playlistItemId_) {
+    player.playlist.currentPlaylistItemId_ = item.playlistItemId_;
+  }
+
   player.poster(item.poster || '');
   player.src(item.sources);
   clearTracks(player);
 
-  // Flag this source as having been set by the playlist plugin. Also set the
-  // flag when the next loadstart happens
-  playlist.currentSourceSetByPlaylist_ = true;
-  player.one('loadstart', () => {
-    playlist.currentSourceSetByPlaylist_ = true;
-  });
-
   player.ready(() => {
-
-    if (item.playlistItemId_) {
-      playlist.currentPlaylistItemId_ = item.playlistItemId_;
-    }
 
     (item.textTracks || []).forEach(player.addRemoteTextTrack.bind(player));
     player.trigger('playlistitem', item.originalValue || item);

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -248,8 +248,9 @@ export default function factory(player, initialList, initialIndex = 0) {
 
       // @todo - Simplify this to `list.slice()` for v5.
       const previousPlaylist = Array.isArray(list) ? list.slice() : null;
+      const nextPlaylist = newList.slice();
 
-      list = newList.slice();
+      list = nextPlaylist.slice();
 
       // Transform any primitive and null values in an input list to objects
       if (list.filter(item => isItemObject(item)).length !== list.length) {
@@ -262,7 +263,7 @@ export default function factory(player, initialList, initialIndex = 0) {
       player.trigger({
         type: 'duringplaylistchange',
         nextIndex: newIndex,
-        nextPlaylist: list,
+        nextPlaylist,
         previousIndex: playlist.currentIndex_,
 
         // @todo - Simplify this to simply pass along `previousPlaylist` for v5.
@@ -292,8 +293,9 @@ export default function factory(player, initialList, initialIndex = 0) {
       // identical sources in the playlist.
       generatePlaylistItemId(list);
     }
+
     // Always return a shallow clone of the playlist list.
-    // We also want to return originalValue if any item in the list has it.
+    //  We also want to return originalValue if any item in the list has it.
     return list.map((item) => item.originalValue || item).slice();
   };
 
@@ -301,12 +303,6 @@ export default function factory(player, initialList, initialIndex = 0) {
   player.on('loadstart', () => {
     if (playlist.currentItem() === -1) {
       autoadvance.reset(player);
-    }
-  });
-
-  player.on('playlistitem', (event, item) => {
-    if (item && item.playlistItemId_) {
-      playlist.currentPlaylistItemId_ = item.playlistItemId_;
     }
   });
 

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -82,15 +82,15 @@ const generatePlaylistItemId = (arr) => {
  * @return  {number}
  *           The index of the playlist item or -1 if not found
  */
-const indexInPlaylistItemIds = (list, currentItemId) => {
-  for (let i = 0; i < list.length; i++) {
-    if (list[i].playlistItemId_ === currentItemId) {
-      return i;
-    }
-  }
+// const indexInPlaylistItemIds = (list, currentItemId) => {
+//   for (let i = 0; i < list.length; i++) {
+//     if (list[i].playlistItemId_ === currentItemId) {
+//       return i;
+//     }
+//   }
 
-  return -1;
-};
+//   return -1;
+// };
 
 /**
  * Given two sources, check to see whether the two sources are equal.
@@ -301,6 +301,7 @@ export default function factory(player, initialList, initialIndex = 0) {
 
   // On a new source, if there is no current item, disable auto-advance.
   player.on('loadstart', () => {
+    playlist.currentSourceSetByPlaylist_ = false;
     if (playlist.currentItem() === -1) {
       autoadvance.reset(player);
     }
@@ -341,7 +342,7 @@ export default function factory(player, initialList, initialIndex = 0) {
         list[playlist.currentIndex_]
       );
     } else {
-      playlist.currentIndex_ = indexInPlaylistItemIds(list, playlist.currentPlaylistItemId_);
+      playlist.currentIndex_ = playlist.indexOf(playlist.player_.currentSrc() || '');
     }
 
     return playlist.currentIndex_;

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -3,6 +3,96 @@ import playItem from './play-item';
 import * as autoadvance from './auto-advance';
 
 /**
+ * Returns whether a playlist item is an object of any kind, excluding null.
+ *
+ * @private
+ *
+ * @param {Object}
+ *         value to be checked
+ *
+ * @return {boolean}
+ *          The result
+ */
+const isItemObject = (value) => {
+  return !!value && typeof value === 'object';
+};
+
+/**
+ * Look through an array of playlist items and transform any primitive
+ * as well as null values to objects. This method also adds a property
+ * to the transformed item containing original value passed in an input list.
+ *
+ * @private
+ *
+ * @param {Array}
+ *         An array of playlist items
+ *
+ * @return {Array}
+ *          A new array with transformed items
+ */
+const transformPrimitiveItems = (arr) => {
+  const list = [];
+  let tempItem;
+
+  arr.forEach(item => {
+    if (!isItemObject(item)) {
+      tempItem = Object(item);
+      tempItem.originalValue = item;
+    } else {
+      tempItem = item;
+    }
+
+    list.push(tempItem);
+  });
+
+  return list;
+};
+
+/**
+ * Generate a unique id for each playlist item object. This id will be used to determine
+ * index of an item in the playlist array for cases where there are multiple items with
+ * the same source set.
+ *
+ * @private
+ *
+ * @param {Array}
+ *         An array of playlist items
+ *
+ * @return {Array}
+ *          The list of playlist items with unique ids
+ */
+const generatePlaylistItemId = (arr) => {
+  let guid = 1;
+
+  arr.forEach(item => {
+    item.playlistItemId_ = guid++;
+  });
+};
+
+/**
+ * Look through an array of playlist items for a specific playlist item id.
+ *
+ * @private
+ * @param   {Array}
+ *           An array of playlist items to look through
+ *
+ * @param   {Player}
+ *           The player containing a playlist
+ *
+ * @return  {number}
+ *           The index of the playlist item or -1 if not found
+ */
+const indexInPlaylistItemIds = (list, currentItemId) => {
+  for (let i = 0; i < list.length; i++) {
+    if (list[i].playlistItemId_ === currentItemId) {
+      return i;
+    }
+  }
+
+  return -1;
+};
+
+/**
  * Given two sources, check to see whether the two sources are equal.
  * If both source urls have a protocol, the protocols must match, otherwise, protocols
  * are ignored.
@@ -161,6 +251,11 @@ export default function factory(player, initialList, initialIndex = 0) {
 
       list = newList.slice();
 
+      // Transform any primitive and null values in an input list to objects
+      if (list.filter(item => isItemObject(item)).length !== list.length) {
+        list = transformPrimitiveItems(list);
+      }
+
       // Mark the playlist as changing during the duringplaylistchange lifecycle.
       changing = true;
 
@@ -192,10 +287,14 @@ export default function factory(player, initialList, initialIndex = 0) {
           player.trigger('playlistchange');
         }, 0);
       }
+      // Add unique id to each playlist item. This id will be used
+      // to determine index in cases where there are more than one
+      // identical sources in the playlist.
+      generatePlaylistItemId(list);
     }
-
     // Always return a shallow clone of the playlist list.
-    return list.slice();
+    // We also want to return originalValue if any item in the list has it.
+    return list.map((item) => item.originalValue || item).slice();
   };
 
   // On a new source, if there is no current item, disable auto-advance.
@@ -205,10 +304,17 @@ export default function factory(player, initialList, initialIndex = 0) {
     }
   });
 
+  player.on('playlistitem', (event, item) => {
+    if (item && item.playlistItemId_) {
+      playlist.currentPlaylistItemId_ = item.playlistItemId_;
+    }
+  });
+
   playlist.currentIndex_ = -1;
   playlist.player_ = player;
   playlist.autoadvance_ = {};
   playlist.repeat_ = false;
+  playlist.currentPlaylistItemId_ = null;
 
   /**
    * Get or set the current item in the playlist.
@@ -222,7 +328,6 @@ export default function factory(player, initialList, initialIndex = 0) {
    *         The current item index.
    */
   playlist.currentItem = (index) => {
-
     // If the playlist is changing, only act as a getter.
     if (changing) {
       return playlist.currentIndex_;
@@ -240,7 +345,7 @@ export default function factory(player, initialList, initialIndex = 0) {
         list[playlist.currentIndex_]
       );
     } else {
-      playlist.currentIndex_ = playlist.indexOf(playlist.player_.currentSrc() || '');
+      playlist.currentIndex_ = indexInPlaylistItemIds(list, playlist.currentPlaylistItemId_);
     }
 
     return playlist.currentIndex_;
@@ -364,9 +469,10 @@ export default function factory(player, initialList, initialIndex = 0) {
     if (changing) {
       return;
     }
+    const newItem = playlist.currentItem(0);
 
     if (list.length) {
-      return list[playlist.currentItem(0)];
+      return list[newItem].originalValue || list[newItem];
     }
 
     playlist.currentIndex_ = -1;
@@ -382,9 +488,10 @@ export default function factory(player, initialList, initialIndex = 0) {
     if (changing) {
       return;
     }
+    const newItem = playlist.currentItem(playlist.lastIndex());
 
     if (list.length) {
-      return list[playlist.currentItem(playlist.lastIndex())];
+      return list[newItem].originalValue || list[newItem];
     }
 
     playlist.currentIndex_ = -1;
@@ -404,7 +511,9 @@ export default function factory(player, initialList, initialIndex = 0) {
     const index = playlist.nextIndex();
 
     if (index !== playlist.currentIndex_) {
-      return list[playlist.currentItem(index)];
+      const newItem = playlist.currentItem(index);
+
+      return list[newItem].originalValue || list[newItem];
     }
   };
 
@@ -422,7 +531,9 @@ export default function factory(player, initialList, initialIndex = 0) {
     const index = playlist.previousIndex();
 
     if (index !== playlist.currentIndex_) {
-      return list[playlist.currentItem(index)];
+      const newItem = playlist.currentItem(index);
+
+      return list[newItem].originalValue || list[newItem];
     }
   };
 

--- a/test/current-item.test.js
+++ b/test/current-item.test.js
@@ -33,104 +33,155 @@ QUnit.module('current-item', {
     destroyFixturePlayer(this);
     this.clock.restore();
   }
-});
+}, function() {
 
-QUnit.test('without a playlist, without a source', function(assert) {
-  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() before tech ready');
+  QUnit.module('without a playlist', function() {
 
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
+    QUnit.test('player without a source', function(assert) {
+      assert.strictEqual(this.player.playlist.currentItem(), -1, 'currentItem() before tech ready');
 
-  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() after tech ready');
-});
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
 
-QUnit.test('without a playlist, with a source', function(assert) {
-  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() before tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), -1, 'currentItem() after tech ready');
+    });
 
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
+    QUnit.test('player with a source', function(assert) {
+      assert.strictEqual(this.player.playlist.currentItem(), -1, 'currentItem() before tech ready');
 
-  this.player.src({
-    src: 'http://vjs.zencdn.net/v/oceans.mp4',
-    type: 'video/mp4'
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
+
+      this.player.src({
+        src: 'http://vjs.zencdn.net/v/oceans.mp4',
+        type: 'video/mp4'
+      });
+
+      assert.strictEqual(this.player.playlist.currentItem(), -1, 'currentItem() after tech ready');
+    });
   });
 
-  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() after tech ready');
-});
+  QUnit.module('with a playlist', function() {
 
-QUnit.test('with a playlist', function(assert) {
-  this.player.playlist(samplePlaylist);
+    QUnit.test('set new source by calling currentItem()', function(assert) {
+      this.player.playlist(samplePlaylist);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() before tech ready');
 
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() after tech ready');
 
-  this.player.playlist.currentItem(1);
+      this.player.playlist.currentItem(1);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 1, 'currentItem() changes the current item');
-});
+      assert.strictEqual(this.player.playlist.currentItem(), 1, 'currentItem() changes the current item');
+    });
 
-QUnit.test('with a playlist, set a new source in the playlist', function(assert) {
-  this.player.playlist(samplePlaylist);
+    QUnit.test('set a new source via src()', function(assert) {
+      this.player.playlist(samplePlaylist);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() before tech ready');
 
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() after tech ready');
 
-  this.player.src({
-    src: 'http://vjs.zencdn.net/v/oceans.mp4',
-    type: 'video/mp4'
+      this.player.src({
+        src: 'http://vjs.zencdn.net/v/oceans.mp4',
+        type: 'video/mp4'
+      });
+
+      assert.strictEqual(this.player.playlist.currentItem(), 2, 'src() changes the current item');
+    });
+
+    QUnit.test('set a new source via src() - source is NOT in the playlist', function(assert) {
+
+      // Populate the player with a playlist without oceans.mp4
+      this.player.playlist(samplePlaylist.slice(0, 2));
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() before tech ready');
+
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() after tech ready');
+
+      this.player.src({
+        src: 'http://vjs.zencdn.net/v/oceans.mp4',
+        type: 'video/mp4'
+      });
+
+      assert.strictEqual(this.player.playlist.currentItem(), -1, 'src() changes the current item');
+    });
   });
 
-  assert.strictEqual(this.player.playlist.currentItem(), 2, 'src() changes the current item');
-});
+  QUnit.module('duplicate sources playlist', function() {
 
-QUnit.test('with a playlist, set a new source not in the playlist', function(assert) {
+    QUnit.test('set new sources by calling currentItem()', function(assert) {
 
-  // Populate the player with a playlist without oceans.mp4
-  this.player.playlist(samplePlaylist.slice(0, 2));
+      // Populate the player with a playlist with another sintel on the end.
+      this.player.playlist(samplePlaylist.concat([{
+        sources: [{
+          src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+          type: 'video/mp4'
+        }],
+        poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+      }]));
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() before tech ready');
 
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
 
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() after tech ready');
 
-  this.player.src({
-    src: 'http://vjs.zencdn.net/v/oceans.mp4',
-    type: 'video/mp4'
+      // Set the playlist to the last item.
+      this.player.playlist.currentItem(3);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 3, 'currentItem() matches the duplicated item that was actually selected');
+
+      // Set the playlist back to the first item (also sintel).
+      this.player.playlist.currentItem(0);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() matches the duplicated item that was actually selected');
+
+      // Set the playlist to the second item (NOT sintel).
+      this.player.playlist.currentItem(1);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 1, 'currentItem() is correct');
+    });
+
+    QUnit.test('set new source by calling src()', function(assert) {
+
+      // Populate the player with a playlist with another sintel on the end.
+      this.player.playlist(samplePlaylist.concat([{
+        sources: [{
+          src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+          type: 'video/mp4'
+        }],
+        poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+      }]));
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() before tech ready');
+
+      // Tick forward to ready the playback tech.
+      this.clock.tick(1);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() after tech ready');
+
+      // Set the playlist to the second item (NOT sintel).
+      this.player.playlist.currentItem(1);
+
+      assert.strictEqual(this.player.playlist.currentItem(), 1, 'currentItem() acted as a setter');
+
+      this.player.src({
+        src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+        type: 'video/mp4'
+      });
+
+      assert.strictEqual(this.player.playlist.currentItem(), 0, 'currentItem() defaults to the first playlist item that matches the current source');
+    });
   });
-
-  assert.strictEqual(this.player.playlist.currentItem(), -1, 'src() changes the current item');
-});
-
-QUnit.test('with a playlist with repeated sources, with a source in the playlist', function(assert) {
-
-  // Populate the player with a playlist with another sintel on the end.
-  this.player.playlist(samplePlaylist.concat([{
-    sources: [{
-      src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
-      type: 'video/mp4'
-    }],
-    poster: 'http://media.w3.org/2010/05/sintel/poster.png'
-  }]));
-
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
-
-  // Tick forward to ready the playback tech.
-  this.clock.tick(1);
-
-  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
-
-  // Set the playlist to the last item.
-  this.player.playlist.currentItem(3);
-
-  assert.strictEqual(this.player.playlist.currentItem(), 3, 'the currentItem() is matches the duplicated item that was actually selected');
 });

--- a/test/current-item.test.js
+++ b/test/current-item.test.js
@@ -1,0 +1,136 @@
+import QUnit from 'qunit';
+import sinon from 'sinon';
+import '../src/plugin';
+
+import {createFixturePlayer, destroyFixturePlayer} from './util';
+
+const samplePlaylist = [{
+  sources: [{
+    src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+    type: 'video/mp4'
+  }],
+  poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+}, {
+  sources: [{
+    src: 'http://media.w3.org/2010/05/bunny/trailer.mp4',
+    type: 'video/mp4'
+  }],
+  poster: 'http://media.w3.org/2010/05/bunny/poster.png'
+}, {
+  sources: [{
+    src: 'http://vjs.zencdn.net/v/oceans.mp4',
+    type: 'video/mp4'
+  }],
+  poster: 'http://www.videojs.com/img/poster.jpg'
+}];
+
+QUnit.module('current-item', {
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    createFixturePlayer(this);
+  },
+  afterEach() {
+    destroyFixturePlayer(this);
+    this.clock.restore();
+  }
+});
+
+QUnit.test('without a playlist, without a source', function(assert) {
+  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() after tech ready');
+});
+
+QUnit.test('without a playlist, with a source', function(assert) {
+  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  this.player.src({
+    src: 'http://vjs.zencdn.net/v/oceans.mp4',
+    type: 'video/mp4'
+  });
+
+  assert.strictEqual(this.player.playlist.currentItem(), -1, 'initial currentItem() after tech ready');
+});
+
+QUnit.test('with a playlist', function(assert) {
+  this.player.playlist(samplePlaylist);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+
+  this.player.playlist.currentItem(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 1, 'currentItem() changes the current item');
+});
+
+QUnit.test('with a playlist, set a new source in the playlist', function(assert) {
+  this.player.playlist(samplePlaylist);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+
+  this.player.src({
+    src: 'http://vjs.zencdn.net/v/oceans.mp4',
+    type: 'video/mp4'
+  });
+
+  assert.strictEqual(this.player.playlist.currentItem(), 2, 'src() changes the current item');
+});
+
+QUnit.test('with a playlist, set a new source not in the playlist', function(assert) {
+
+  // Populate the player with a playlist without oceans.mp4
+  this.player.playlist(samplePlaylist.slice(0, 2));
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+
+  this.player.src({
+    src: 'http://vjs.zencdn.net/v/oceans.mp4',
+    type: 'video/mp4'
+  });
+
+  assert.strictEqual(this.player.playlist.currentItem(), -1, 'src() changes the current item');
+});
+
+QUnit.test('with a playlist with repeated sources, with a source in the playlist', function(assert) {
+
+  // Populate the player with a playlist with another sintel on the end.
+  this.player.playlist(samplePlaylist.concat([{
+    sources: [{
+      src: 'http://media.w3.org/2010/05/sintel/trailer.mp4',
+      type: 'video/mp4'
+    }],
+    poster: 'http://media.w3.org/2010/05/sintel/poster.png'
+  }]));
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() before tech ready');
+
+  // Tick forward to ready the playback tech.
+  this.clock.tick(1);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 0, 'initial currentItem() after tech ready');
+
+  // Set the playlist to the last item.
+  this.player.playlist.currentItem(3);
+
+  assert.strictEqual(this.player.playlist.currentItem(), 3, 'the currentItem() is matches the duplicated item that was actually selected');
+});

--- a/test/player-proxy-maker.js
+++ b/test/player-proxy-maker.js
@@ -12,17 +12,7 @@ const proxy = (props) => {
     addRemoteTextTrack: () => {},
     removeRemoteTextTrack: () => {},
     remoteTextTracks: () => {},
-    playlist: {
-      autoadvance_: {},
-      currentIndex_: -1,
-      autoadvance: () => {},
-      contains: () => {},
-      currentItem: () => {},
-      first: () => {},
-      indexOf: () => {},
-      next: () => {},
-      previous: () => {}
-    },
+    playlist: () => [],
     ready: (cb) => cb(),
     setTimeout: (cb, wait) => window.setTimeout(cb, wait),
     clearTimeout: (id) => window.clearTimeout(id)
@@ -30,6 +20,16 @@ const proxy = (props) => {
 
   player.constructor = videojs.getComponent('Player');
   player.playlist.player_ = player;
+
+  player.playlist.autoadvance_ = {};
+  player.playlist.currentIndex_ = -1;
+  player.playlist.autoadvance = () => {};
+  player.playlist.contains = () => {};
+  player.playlist.currentItem = () => {};
+  player.playlist.first = () => {};
+  player.playlist.indexOf = () => {};
+  player.playlist.next = () => {};
+  player.playlist.previous = () => {};
 
   return player;
 };

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,22 @@
 import document from 'global/document';
 import videojs from 'video.js';
 
+/**
+ * Destroy a fixture player.
+ *
+ * @param  {Object} context
+ *         A testing context.
+ */
 export function destroyFixturePlayer(context) {
   context.player.dispose();
 }
 
+/**
+ * Create a fixture player.
+ *
+ * @param  {Object} context
+ *         A testing context.
+ */
 export function createFixturePlayer(context) {
   context.video = document.createElement('video');
   context.fixture = document.querySelector('#qunit-fixture');

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,19 @@
+import document from 'global/document';
+import videojs from 'video.js';
+
+export function destroyFixturePlayer(context) {
+  context.player.dispose();
+}
+
+export function createFixturePlayer(context) {
+  context.video = document.createElement('video');
+  context.fixture = document.querySelector('#qunit-fixture');
+  context.fixture.appendChild(context.video);
+
+  context.playerIsReady = false;
+  context.player = videojs(context.video, {}, () => {
+    context.playerIsReady = true;
+  });
+
+  context.player.playlist();
+}


### PR DESCRIPTION
Fixes #142 

This fixes a regression introduced in #115. The core issue was that we lost the old behavior of falling back to detecting the current item based on its source URL and relied exclusively on the new, internal `playlistItemId_`.

The reported issue (#142) indicated that the `currentItem()` return value before a source was set was now `-1` where previously it was `0`. This is a consequence of that change and has been fixed.

Other issues were discovered in this process. In some cases, we were leaking the internal representation of playlists. Most importantly, though, was the realization that the plugin no longer behaved correctly when a source was set from outside the playlist API (e.g. via `player.src()`).