### PR TITLE
Fix: Poster hidden when item index > 0

### DIFF
--- a/src/auto-advance.js
+++ b/src/auto-advance.js
@@ -72,7 +72,8 @@ const setup = (player, delay) => {
     player.playlist.autoadvance_.timeout = player.setTimeout(() => {
       reset(player);
       player.off('play', cancelOnPlay);
-      player.playlist.next();
+      // Poster should be suppressed when auto-advancing
+      player.playlist.next(true);
     }, delay * 1000);
   };
 

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -40,7 +40,7 @@ const playItem = (player, item, suppressPoster = false) => {
     player.playlist.currentPlaylistItemId_ = item.playlistItemId_;
   }
 
-  player.poster(item.poster || '');
+  player.poster(suppressPoster ? '' : item.poster || '');
   player.src(item.sources);
   clearTracks(player);
 

--- a/src/play-item.js
+++ b/src/play-item.js
@@ -25,11 +25,13 @@ const clearTracks = (player) => {
  *
  * @param  {Object} item
  *         A source from the playlist.
+ * @param {boolean} [suppressPoster]
+ *         Should the native poster be suppressed? Defaults to false.
  *
  * @return {Player}
  *         The player that is now playing the item
  */
-const playItem = (player, item) => {
+const playItem = (player, item, suppressPoster = false) => {
   const replay = !player.paused() || player.ended();
 
   player.trigger('beforeplaylistitem', item.originalValue || item);

--- a/src/playlist-maker.js
+++ b/src/playlist-maker.js
@@ -290,11 +290,13 @@ export default function factory(player, initialList, initialIndex = 0) {
    *
    * @param  {number} [index]
    *         If given as a valid value, plays the playlist item at that index.
+   * @param {boolean} [suppressPoster]
+   *         Should the native poster be suppressed? Defaults to false.
    *
    * @return {number}
    *         The current item index.
    */
-  playlist.currentItem = (index) => {
+  playlist.currentItem = (index, suppressPoster) => {
     // If the playlist is changing, only act as a getter.
     if (changing) {
       return playlist.currentIndex_;
@@ -310,19 +312,9 @@ export default function factory(player, initialList, initialIndex = 0) {
       playlist.currentIndex_ = index;
       playItem(
         playlist.player_,
-        list[playlist.currentIndex_]
+        list[playlist.currentIndex_],
+        suppressPoster
       );
-
-      // When playing multiple videos in a playlist the videojs PosterImage
-      // will be hidden using CSS. However, in some browsers the native poster
-      // attribute will briefly appear while the new source loads. Prevent
-      // this by hiding every poster after the first play list item. This
-      // doesn't cover every use case for showing/hiding the poster, but
-      // it will significantly improve the user experience.
-      if (index > 0) {
-        player.poster('');
-      }
-
       return playlist.currentIndex_;
     }
 
@@ -604,10 +596,12 @@ export default function factory(player, initialList, initialIndex = 0) {
   /**
    * Plays the next item in the playlist.
    *
+   * @param {boolean} [suppressPoster]
+   *         Should the native poster be suppressed? Defaults to false.
    * @return {Object|undefined}
    *         Returns undefined and has no side effects if on last item.
    */
-  playlist.next = () => {
+  playlist.next = (suppressPoster = false) => {
     if (changing) {
       return;
     }
@@ -615,7 +609,7 @@ export default function factory(player, initialList, initialIndex = 0) {
     const index = playlist.nextIndex();
 
     if (index !== playlist.currentIndex_) {
-      const newItem = playlist.currentItem(index);
+      const newItem = playlist.currentItem(index, suppressPoster);
 
       return list[newItem].originalValue || list[newItem];
     }

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -167,7 +167,7 @@ QUnit.test('playlist.currentItem() works as expected', function(assert) {
   assert.equal(playlist.currentItem(-Infinity), 2, 'cannot change to an invalid item');
 });
 
-QUnit.test('playlist.currentItem() shows the poster for the first video', function(assert) {
+QUnit.test('playlist.currentItem() shows a poster by default', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, videoList);
 
@@ -175,14 +175,12 @@ QUnit.test('playlist.currentItem() shows the poster for the first video', functi
   assert.notEqual(player.poster(), '', 'poster is shown for playlist index 0');
 });
 
-QUnit.test('playlist.currentItem() hides the poster for all videos after the first', function(assert) {
+QUnit.test('playlist.currentItem() will hide the poster if suppressPoster param is true', function(assert) {
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, videoList);
 
-  for (let i = 1; i <= playlist.lastIndex(); i++) {
-    playlist.currentItem(i);
-    assert.equal(player.poster(), '', 'poster is hidden for playlist index ' + i);
-  }
+  playlist.currentItem(0, true);
+  assert.equal(player.poster(), '', 'poster is suppressed');
 });
 
 QUnit.test('playlist.currentItem() returns -1 with an empty playlist', function(assert) {

--- a/test/playlist-maker.test.js
+++ b/test/playlist-maker.test.js
@@ -179,7 +179,7 @@ QUnit.test('playlist.currentItem() will hide the poster if suppressPoster param 
   const player = playerProxyMaker();
   const playlist = playlistMaker(player, videoList);
 
-  playlist.currentItem(0, true);
+  playlist.currentItem(1, true);
   assert.equal(player.poster(), '', 'poster is suppressed');
 });
 


### PR DESCRIPTION
## Description
Changes in #243 prevent poster "flashing" in auto-advance scenarios but introduces a new issue whereby posters are hidden if the playlist is set to an item index of > 0, whether or not it's auto-advancing. The v6 major rewrite does address this problem however it may be some time before existing integrations can be fully tested with and migrated to v6. As an interim measure, these relatively minor changes take the idea of a parameter [from v6](https://github.com/videojs/videojs-playlist/blob/350ea3b472a196c8ea27b2aabd9ef03368a59722/src/playlist-plugin.js#L109) and implement it against the v5 codebase. 

To reproduce the issue, checkout the v5.1.0 tag. Before running `npm start`, in `index.html` change the URL for the poster of the second item in the playlist from 'http://www.videojs.com/img/poster.jpg' (this is a 404) to 'http://vjs.zencdn.net/v/oceans.png'.
run `npm start`
Visit `http://localhost:9999/`
in the browser dev-tools console, enter `player.playlist.next()`. Observe that no poster is visible. Verify that `player.poster_` shows a value of `''`.

To manually test these changes, checkout this branch.
No need to update `index.html` :) 
Visit `http://localhost:9999/`
in the browser dev-tools console, enter `player.playlist.next()`. Observe that the poster is visible and `player.poster_` shows a value of `http://vjs.zencdn.net/v/oceans.png`.

We can verify that posters are still suppressed in an auto-advance setup by setting the auto-advance to a value in the UI on the test page and letting the playlist play in Chrome or Firefox. No poster flashes should be observed.

## Specific Changes proposed
* Add `suppressPoster` param  to `playItem`, `playlist.currentItem` and `playlist.next`. The parameter defaults to false.
* Set the parameter as `true` when calling `playlist.next` in `autoadvance.setup`

fixes #253 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
